### PR TITLE
fix: リスコフ置き換え原則サンプルコード改善(implements制約宣言追加)

### DIFF
--- a/docs/liskov-substitution-principle.md
+++ b/docs/liskov-substitution-principle.md
@@ -433,7 +433,7 @@ class Rectangle implements Shape {
   }
 }
 
-class Square {
+class Square implements Shape {
   constructor(private length: number = 0) {}
   setLength(length: number) {
     this.length = length;


### PR DESCRIPTION
## 概要
リスコフ置き換え原則（LSP）の説明に使われているサンプルコードに、
`implements` による型制約の宣言が欠けていたため追加しました。

## 変更内容
- `implements` 制約宣言を追加

## 変更理由
インターフェースの制約が暗黙的になっており、
LSPの原則がコードから読み取りにくい状態でした。
明示的な宣言を加えることで、意図がより伝わりやすくなると考えました。

## 備考
小さな変更ですが、学習者がコードを読む際の助けになると思いPRを出しました。
お気に召さない場合はクローズいただいて構いません🙏